### PR TITLE
Tweak the tagline

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,6 +18,6 @@ markup:
       unsafe: true
 
 params:
-  tagline: A meetup for makers, coders, designers, 3d printers, and all tech-minded folks in Crieff and the surrounding areas.
+  tagline: A meetup for makers, coders, designers, and other tech-minded folk in Crieff and the surrounding areas.
   images:
     - twitter_card.png


### PR DESCRIPTION
The current tagline needs a bit of a change as it suggests that actual 3D printers are welcome at the meetings. As 3D printer enthusiasts fall firmly under the scope of "maker", lets just remove that entirely.

Replace "all" with "other" as it makes it read a bit better to me.

Replace "folks" with "folk" as this can also be used as the plural and also reads a bit better to me.